### PR TITLE
Implemented a region map that is used in bandwidth mode to further limit...

### DIFF
--- a/DMXVNCServer.hh
+++ b/DMXVNCServer.hh
@@ -14,6 +14,37 @@
 #include "DMXResource.hh"
 #include "UFile.hh"
 
+class ImageMap
+{
+public:
+	void Resize(int height, int width);
+	void Clear();
+	int GetChangedRegionRatio();
+
+	int pixelsPerRegion = 50;
+	int height = 0;
+	int width = 0;
+	int mapWidth = 0;
+	int mapHeight = 0;
+	std::vector<bool> imageMap;
+};
+
+class BandwidthController
+{
+public:
+	void ControlMode(int changedRegionRatio);
+
+	int smallUpdateFramesSize = 10;
+	int largeUpdateFramesSize = 30;
+
+	int smallUpdateFramesSwitchCount = 5;
+	int largeUpdateFramesSwitchCount = 5;
+
+	int largeUpdateFrames = 0;
+	int smallUpdateFrames = 0;
+	bool largeFrameMode = false;
+};
+
 class DMXVNCServer
 {
 public:
@@ -50,6 +81,9 @@ private:
 	std::string password;
 	int clients = 0;
 
+	BandwidthController bandwidthController;
+
+	ImageMap imageMap;
 	std::vector<char> frameBuffer;
 	std::vector<char> imageBuffer1;
 	std::vector<char> imageBuffer2;

--- a/main.cpp
+++ b/main.cpp
@@ -43,14 +43,14 @@ int main(int argc, char *argv[])
 		int relativeMode = 0;
 		std::string password;
 		int port = 0;
-		bool safeMode = false;
-		bool bandwidthMode = false;
+		bool safeMode = true;
+		bool bandwidthMode = true;
 
 		static struct option long_options[] = {
 			{ "relative", no_argument, nullptr, 'r' },
 			{ "absolute", no_argument, nullptr, 'a' },
-			{ "safe", no_argument, nullptr, 'f' },
-			{ "bandwidth", no_argument, nullptr, 'b' },
+			{ "unsafe", no_argument, nullptr, 'u' },
+			{ "fullscreen", no_argument, nullptr, 'f' },
 			{ "password", required_argument, nullptr, 'P' },
 			{ "port", required_argument, nullptr, 'p' },
 			{ "screen", required_argument, nullptr, 's' },
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 		};
 
 		int c;
-		while (-1 != (c = getopt_long(argc, argv, "abfP:p:rs:", long_options, nullptr))) {
+		while (-1 != (c = getopt_long(argc, argv, "abfP:p:rs:u", long_options, nullptr))) {
 			switch (c) {
 			case 'a':
 				relativeMode = 0;
@@ -69,12 +69,12 @@ int main(int argc, char *argv[])
 				relativeMode = 1;
 				break;
 
-			case 'f':
-				safeMode = 1;
+			case 'u':
+				safeMode = false;
 				break;
 
-			case 'b':
-				bandwidthMode = 1;
+			case 'f':
+				bandwidthMode = false;
 				break;
 
 			case 'P':
@@ -126,12 +126,12 @@ void usage(const char *programName)
 		"Usage: " << programName << " [OPTION]...\n"
 		"\n"
 		"  -a, --absolute               absolute mouse movements\n"
-		"  -b, --bandwidth              saves bandwidth at a small performance penalty\n"
-		"  -f, --safe                   more robust handling of resoltion change at a\n"
-		"                               small performance penalty\n"
+		"  -f, --fullscreen             always runs fullscreen mode\n"
 		"  -p, --port=PORT              makes vnc available on the speficied port\n"
 		"  -P, --password=PASSWORD      protects the session with PASSWORD\n"
 		"  -r, --relative               relative mouse movements\n"
 		"  -s, --screen=SCREEN          opens the specified screen number\n"
+		"  -u, --unsafe                 disables more robust handling of resolution\n"
+		"                               change at a small performance gain\n"
 		"      --help                   displays this help and exit\n";
 }


### PR DESCRIPTION
... the amount of data passed to vnc clients. This gives a substantially better performance in e.g. Kodi menus.

Bandwidth mode will now adapt to the amount of changes in the frame buffer automatically switching to the non-bandwidth mode when large changes occur, and switching back again when large changes does not occur. This maximizes performance for both video and menus.
